### PR TITLE
Fix PGMQ message parsing in process webhook

### DIFF
--- a/src/app/api/webhooks/process-flight-alerts/route.ts
+++ b/src/app/api/webhooks/process-flight-alerts/route.ts
@@ -9,7 +9,7 @@ const BATCH_SIZE = 10;
 
 type QueueRow = {
   msg_id: number;
-  msg: { userId?: string } | null;
+  message: { userId?: string } | null;
 };
 
 export async function POST(request: Request) {
@@ -43,7 +43,7 @@ export async function POST(request: Request) {
     const skipped: string[] = [];
 
     for (const row of messages) {
-      const message = row.msg ?? {};
+      const message = row.message ?? {};
       const userId = typeof message.userId === "string" ? message.userId : null;
 
       if (!userId) {

--- a/src/components/sign-out-button.tsx
+++ b/src/components/sign-out-button.tsx
@@ -3,8 +3,8 @@
 import { Loader2, LogOut } from "lucide-react";
 import { type ComponentProps, useTransition } from "react";
 import { Button } from "@/components/ui/button";
-import { createClient } from "@/lib/supabase/client";
 import { isSecureRoute } from "@/lib/routes";
+import { createClient } from "@/lib/supabase/client";
 
 type ButtonComponentProps = ComponentProps<typeof Button>;
 


### PR DESCRIPTION
## Summary
- use the correct \message\ field returned by pgmq when reading queue items
- ensure alerts processing webhook can extract the user id from queued payloads
- include Biome import order clean-up

## Testing
- bun run lint
- bun x tsc --noEmit *(fails: existing type issues in tests and generated Next.js validators)*
- bun x vitest run *(fails: Vitest config attempts to require ESM Vite package)*
- bun run build *(fails: missing mandatory environment variables in local context)*