### PR TITLE
Optimize home page MapKit loading and airport caching

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -74,6 +74,20 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <link
+          rel="preconnect"
+          href="https://cdn.apple-mapkit.com"
+          crossOrigin=""
+        />
+        <link rel="dns-prefetch" href="https://cdn.apple-mapkit.com" />
+        <link
+          rel="preload"
+          as="script"
+          href="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js"
+          crossOrigin="anonymous"
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,28 +1,40 @@
-"use client";
-
+import dynamic from "next/dynamic";
 import { Suspense } from "react";
-import { FlightExplorer } from "@/components/flight-explorer";
-import { Header } from "@/components/header";
-import { trpc } from "@/lib/trpc/react";
 
-/**
- * Home page (/) - Browse flights and explore airports on the map.
- * When user searches, they're redirected to /search with query params.
- */
-export default function Home() {
-  const { data: airportSearchData, isLoading: isLoadingAirports } =
-    trpc.useQuery(["airports.search", { limit: 10000 }]);
-  const airports = airportSearchData?.airports ?? [];
-  const totalAirports = airportSearchData?.total ?? airports.length;
+import { Header } from "@/components/header";
+import { getCachedAirports } from "@/lib/airports.server";
+
+const FlightExplorer = dynamic(
+  () => import("@/components/flight-explorer/flight-explorer-client"),
+  {
+    loading: () => <FlightExplorerFallback />,
+  },
+);
+
+export const revalidate = 3600;
+
+function FlightExplorerFallback() {
+  return (
+    <div className="flex-1 flex items-center justify-center bg-muted/15">
+      <div className="flex flex-col items-center gap-3 text-muted-foreground">
+        <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-primary border-r-transparent" />
+        <p className="text-sm font-medium">Loading flight explorer…</p>
+      </div>
+    </div>
+  );
+}
+
+export default async function Home() {
+  const { airports, total } = await getCachedAirports();
 
   return (
     <div className="flex flex-col h-screen w-full bg-background">
       <Header />
-      <Suspense fallback={null}>
+      <Suspense fallback={<FlightExplorerFallback />}>
         <FlightExplorer
           airports={airports}
-          totalAirports={totalAirports}
-          isLoadingAirports={isLoadingAirports}
+          totalAirports={total}
+          isLoadingAirports={false}
         />
       </Suspense>
     </div>

--- a/src/components/flight-explorer/flight-explorer-client.tsx
+++ b/src/components/flight-explorer/flight-explorer-client.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { FlightExplorer, type FlightExplorerProps } from "./flight-explorer";
+
+export default function FlightExplorerClient(props: FlightExplorerProps) {
+  return <FlightExplorer {...props} />;
+}

--- a/src/components/flight-explorer/flight-explorer.tsx
+++ b/src/components/flight-explorer/flight-explorer.tsx
@@ -8,7 +8,7 @@ import { AirportMapView } from "./airport-map-view";
 import { FlightPricePanel } from "./flight-price-panel";
 import { RouteSearchPanel } from "./route-search-panel";
 
-type FlightExplorerProps = {
+export type FlightExplorerProps = {
   airports: AirportData[];
   totalAirports: number;
   isLoadingAirports: boolean;

--- a/src/components/sign-out-button.tsx
+++ b/src/components/sign-out-button.tsx
@@ -3,8 +3,8 @@
 import { Loader2, LogOut } from "lucide-react";
 import { type ComponentProps, useTransition } from "react";
 import { Button } from "@/components/ui/button";
-import { createClient } from "@/lib/supabase/client";
 import { isSecureRoute } from "@/lib/routes";
+import { createClient } from "@/lib/supabase/client";
 
 type ButtonComponentProps = ComponentProps<typeof Button>;
 

--- a/src/core/alerts-service.test.ts
+++ b/src/core/alerts-service.test.ts
@@ -59,7 +59,7 @@ describe("alerts-service", () => {
       mockedAlertsDb.validateAirportExists.mockResolvedValueOnce(false); // from airport
 
       const filters = createMockAlertFilters({
-        route: { from: "XXX" },
+        route: { from: "XXX", to: "JFK" },
       });
 
       await expect(validateAlertFilters(filters)).rejects.toThrow(
@@ -72,7 +72,7 @@ describe("alerts-service", () => {
       mockedAlertsDb.validateAirportExists.mockResolvedValueOnce(false); // to airport
 
       const filters = createMockAlertFilters({
-        route: { to: "YYY" },
+        route: { from: "LAX", to: "YYY" },
       });
 
       await expect(validateAlertFilters(filters)).rejects.toThrow(

--- a/src/lib/airports.server.ts
+++ b/src/lib/airports.server.ts
@@ -1,0 +1,11 @@
+import "server-only";
+
+import { cache } from "react";
+
+import { searchAirports } from "@/server/services/airports";
+
+const DEFAULT_HOME_LIMIT = 10000;
+
+export const getCachedAirports = cache(async () => {
+  return searchAirports({ limit: DEFAULT_HOME_LIMIT });
+});

--- a/src/lib/notifications/__tests__/notifications.test.ts
+++ b/src/lib/notifications/__tests__/notifications.test.ts
@@ -14,6 +14,7 @@ vi.mock("../resend-client", () => ({
   sendWithResend: sendWithResendMock,
 }));
 
+import type { FlightOptionSummary } from "@/lib/notifications";
 import {
   renderDailyPriceUpdateEmail,
   renderPriceDropAlertEmail,
@@ -31,7 +32,7 @@ const baseAlert = {
   priceLimit: { amount: 350, currency: "USD" },
 };
 
-const sampleFlight = {
+const sampleFlight: FlightOptionSummary = {
   totalPrice: 280,
   currency: "USD",
   slices: [
@@ -55,7 +56,7 @@ const sampleFlight = {
       ],
     },
   ],
-} as const;
+};
 
 beforeEach(() => {
   sendWithResendMock.mockClear();

--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -13,4 +13,24 @@ export default createNextApiHandler({
 
     console.error(`tRPC failed on ${path ?? "unknown path"}:`, error);
   },
+  responseMeta({ type, errors, paths }) {
+    if (type !== "query" || errors.length > 0) {
+      return {};
+    }
+
+    const isAirportsSearch =
+      Array.isArray(paths) &&
+      paths.length === 1 &&
+      paths[0] === "airports.search";
+
+    if (!isAirportsSearch) {
+      return {};
+    }
+
+    return {
+      headers: {
+        "Cache-Control": "s-maxage=3600, stale-while-revalidate=300",
+      },
+    };
+  },
 });


### PR DESCRIPTION
## Summary
- serve airport data via new cached server helper and convert the home page to an async server component that dynamically loads the MapKit explorer
- preload Apple MapKit assets in the root layout and expose the flight explorer client wrapper for dynamic usage
- add CDN caching headers on airports search endpoint and tighten test fixtures/types to satisfy strict checking

## Testing
- bun run lint
- bunx tsc --noEmit
- bun run build (with placeholder env vars)
- bun run test *(fails: vitest config requires ESM support for Vite; bunx vitest run exits with ERR_REQUIRE_ESM)*
