### PR TITLE
feat: configure Open Graph metadata to match specifications

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -52,13 +52,12 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    site: "@graypane",
     title: "Flight Search & Alerts",
     description:
       "Track fare trends and manage flight alerts with the GrayPane dashboard on graypane.com.",
     images: [
       {
-        url: "/opengraph-image",
+        url: "/twitter-image",
         width: 1200,
         height: 630,
         alt: "GrayPane flight pricing dashboard",

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -8,8 +8,8 @@ export default function DefaultOpenGraphImage() {
   return new ImageResponse(
     <OgCard
       badge="Graypane"
-      title="Stay ahead of airfare changes"
-      subtitle="Monitor fare trends, explore airports worldwide, and set price alerts in one streamlined dashboard."
+      title="Flight Search & Alerts"
+      subtitle="Monitor flight prices, explore fare history, and stay ahead with personalized alerts."
       footer="Real-time flight intelligence"
     />,
     {

--- a/src/app/search/layout.tsx
+++ b/src/app/search/layout.tsx
@@ -119,7 +119,10 @@ export async function generateMetadata({
   if (dateTo) query.set("dateTo", format(dateTo, "yyyy-MM-dd"));
   if (windowDays) query.set("searchWindowDays", windowDays.toString());
 
-  const imagePath = `/search/opengraph-image${
+  const ogImagePath = `/search/opengraph-image${
+    query.toString() ? `?${query.toString()}` : ""
+  }`;
+  const twitterImagePath = `/search/twitter-image${
     query.toString() ? `?${query.toString()}` : ""
   }`;
 
@@ -137,7 +140,7 @@ export async function generateMetadata({
       url: "/search",
       images: [
         {
-          url: imagePath,
+          url: ogImagePath,
           width: 1200,
           height: 630,
           alt: routeLabel
@@ -152,7 +155,7 @@ export async function generateMetadata({
       description,
       images: [
         {
-          url: imagePath,
+          url: twitterImagePath,
           width: 1200,
           height: 630,
           alt: routeLabel

--- a/src/app/search/twitter-image.tsx
+++ b/src/app/search/twitter-image.tsx
@@ -2,4 +2,6 @@ import SearchOpenGraphImage, { contentType, size } from "./opengraph-image";
 
 export { contentType, size };
 
+// For now, use the same sophisticated chart generation as OG image
+// This could be customized for Twitter's specific format if needed
 export default SearchOpenGraphImage;

--- a/src/app/twitter-image.tsx
+++ b/src/app/twitter-image.tsx
@@ -1,5 +1,19 @@
-import DefaultOpenGraphImage from "./opengraph-image";
+import { ImageResponse } from "next/og";
+import { OG_IMAGE_SIZE, OgCard } from "@/lib/og/card";
 
-export { contentType, size } from "./opengraph-image";
+export const size = OG_IMAGE_SIZE;
+export const contentType = "image/png";
 
-export default DefaultOpenGraphImage;
+export default function TwitterImage() {
+  return new ImageResponse(
+    <OgCard
+      badge="Graypane"
+      title="Flight Search & Alerts"
+      subtitle="Track fare trends and manage flight alerts with the GrayPane dashboard on graypane.com."
+      footer="Real-time flight intelligence"
+    />,
+    {
+      ...size,
+    },
+  );
+}


### PR DESCRIPTION
- Update root layout with proper OG/Twitter card configuration
- Separate OpenGraph and Twitter image generation endpoints
- Update OpenGraph image title to 'Flight Search & Alerts'
- Configure Twitter image with distinct description
- Update search page to use separate image paths for OG vs Twitter
- Remove Twitter @site handle from root layout
- Ensure all metadata matches provided specifications