### PR TITLE
Update search window limits: max 150 days, default 90 days

### DIFF
--- a/src/components/flight-explorer/constants.ts
+++ b/src/components/flight-explorer/constants.ts
@@ -11,8 +11,8 @@ export const USD_FORMATTER = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 0,
 });
 
-export const SEARCH_WINDOW_OPTIONS = [30, 60, 90, 120, 150, 180] as const;
-export const DEFAULT_SEARCH_WINDOW_DAYS = 30;
+export const SEARCH_WINDOW_OPTIONS = [30, 60, 90, 120, 150] as const;
+export const DEFAULT_SEARCH_WINDOW_DAYS = 90;
 
 export const MAX_SEARCH_DAYS =
   SEARCH_WINDOW_OPTIONS[SEARCH_WINDOW_OPTIONS.length - 1];


### PR DESCRIPTION
## Summary

This PR updates the flight search window configuration:

### Changes
- **Maximum search window**: Reduced from 180 days to 150 days
- **Default search window**: Increased from 30 days to 90 days
- Removed 180-day option from SEARCH_WINDOW_OPTIONS array

### Impact
- Users will now have a maximum search window of 150 days instead of 180
- The default search will now look ahead 90 days instead of 30 days, providing more comprehensive results by default
- The MAX_SEARCH_DAYS constant is automatically updated to 150 based on the last element in the array

### Testing
- ✅ Code quality checks passed (Biome lint)
- ✅ TypeScript compilation successful
- No behavioral changes to existing functionality - only configuration value updates

### Modified Files
- `src/components/flight-explorer/constants.ts`