### PR TITLE
Enable Sentry structured logs for Cloudflare workers

### DIFF
--- a/src/workers/utils/logger.test.ts
+++ b/src/workers/utils/logger.test.ts
@@ -4,7 +4,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mockConsole } from "../test/setup";
-import { workerLogger } from "./logger";
+import { setSentryLogger, workerLogger } from "./logger";
 
 describe("workerLogger", () => {
   let consoleMock: ReturnType<typeof mockConsole>;
@@ -73,5 +73,31 @@ describe("workerLogger", () => {
     expect(
       logEntry.timestamp >= beforeLog && logEntry.timestamp <= afterLog,
     ).toBe(true);
+  });
+
+  test("forwards logs to Sentry logger when available", () => {
+    const sentryInfoCalls: Array<{
+      message: string;
+      attributes?: Record<string, unknown>;
+    }> = [];
+
+    setSentryLogger({
+      info: (message: string, attributes?: Record<string, unknown>) => {
+        sentryInfoCalls.push({ message, attributes });
+      },
+    });
+
+    try {
+      workerLogger.info("Sentry test", { requestId: "req-123" });
+
+      expect(sentryInfoCalls).toHaveLength(1);
+      const [{ message, attributes }] = sentryInfoCalls;
+      expect(message).toBe("Sentry test");
+      expect(attributes).toBeDefined();
+      expect(attributes?.requestId).toBe("req-123");
+      expect(attributes?.timestamp).toBeDefined();
+    } finally {
+      setSentryLogger(undefined);
+    }
   });
 });

--- a/src/workers/utils/sentry.test.ts
+++ b/src/workers/utils/sentry.test.ts
@@ -15,6 +15,7 @@ describe("Sentry utilities", () => {
       dsn: undefined as any,
       environment: "test",
       tracesSampleRate: 1.0,
+      enableLogs: true,
     });
   });
 
@@ -30,6 +31,7 @@ describe("Sentry utilities", () => {
     expect(options?.dsn).toBe("https://test@sentry.io/123");
     expect(options?.environment).toBe("staging");
     expect(options?.tracesSampleRate).toBe(1.0);
+    expect(options?.enableLogs).toBe(true);
   });
 
   test("getSentryOptions uses default environment", () => {
@@ -40,6 +42,7 @@ describe("Sentry utilities", () => {
 
     const options = getSentryOptions(env);
     expect(options?.environment).toBe("production");
+    expect(options?.enableLogs).toBe(true);
   });
 
   // Note: Testing Sentry wrapper functions (captureException, setUser, etc.)

--- a/src/workers/utils/sentry.ts
+++ b/src/workers/utils/sentry.ts
@@ -11,6 +11,7 @@ export function getSentryOptions(env: WorkerEnv) {
     dsn: env.SENTRY_DSN,
     environment: env.SENTRY_ENVIRONMENT || "production",
     tracesSampleRate: 1.0,
+    enableLogs: true,
   };
 }
 


### PR DESCRIPTION
## Summary
- enable structured log forwarding to Sentry in the worker Sentry config
- forward workerLogger output to Sentry.logger while preserving structured console output
- add/update tests covering the new logging behaviour

## Testing
- bun run lint
- bun run test:workers