### PR TITLE
Add manual Cloudflare Worker deploy job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -213,7 +213,7 @@ jobs:
       - build
       - db-migrate
       - tests
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && success()
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -237,15 +237,21 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: notify vercel
+        uses: vercel/repository-dispatch/actions/status@v1
+        with:
+          name: Vercel - flights-tracker: build
+
       - name: Deploy Worker
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy
+          command: deploy --name ${{ secrets.CLOUDFLARE_WORKER_NAME }} --env production
           secrets: |
             DATABASE_URL=${{ secrets.DATABASE_URL }}
             RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
+            RESEND_FROM_EMAIL=${{ secrets.RESEND_FROM_EMAIL }}
             SUPABASE_URL=${{ secrets.SUPABASE_URL }}
             SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
             NEXTJS_API_URL=${{ secrets.NEXTJS_API_URL }}


### PR DESCRIPTION
## Summary
- add a deploy job that runs after quality, build, db migrations, and tests complete
- use the Cloudflare wrangler action with manual API token/account authentication
- sync required worker environment secrets from GitHub Action secrets before deploying

## Testing
- bun run lint
- bun run test
