### PR TITLE
Remove Sentry instrumentWorkflowWithSentry to resolve workflow timeouts

### DIFF
--- a/src/workers/workflows/check-flight-alerts.ts
+++ b/src/workers/workflows/check-flight-alerts.ts
@@ -9,7 +9,6 @@ import {
   type WorkflowEvent,
   type WorkflowStep,
 } from "cloudflare:workers";
-import * as Sentry from "@sentry/cloudflare";
 import { getUserIdsWithActiveDailyAlerts } from "../adapters/alerts.db";
 import type { WorkerEnv } from "../env";
 import { workerLogger } from "../utils/logger";
@@ -17,8 +16,21 @@ import { withSentryMonitor } from "../utils/monitor-wrapper";
 import { addBreadcrumb, captureException } from "../utils/sentry";
 
 /**
- * Base workflow that handles the core business logic
- * Separated from monitoring concerns for clean separation of responsibilities
+ * CheckFlightAlertsWorkflow
+ * Triggered by cron every 6 hours
+ * Fetches all user IDs with active daily alerts and queues them
+ *
+ * Note: This workflow is NOT wrapped with Sentry's instrumentWorkflowWithSentry
+ * to avoid interference with Cloudflare's workflow hibernation/resumption mechanism.
+ *
+ * However, it IS wrapped with withSentryMonitor for cron monitoring.
+ *
+ * Error tracking is preserved through:
+ * - captureException() calls within workflow logic
+ * - addBreadcrumb() for execution trails
+ * - workerLogger for structured logging
+ * - withSentry wrapper at the handler level (index.ts)
+ * - withSentryMonitor for cron check-in tracking
  */
 class CheckFlightAlertsWorkflowBase extends WorkflowEntrypoint<
   WorkerEnv,
@@ -97,19 +109,12 @@ class CheckFlightAlertsWorkflowBase extends WorkflowEntrypoint<
   }
 }
 
-// Export with Sentry instrumentation
-const InstrumentedWorkflow = Sentry.instrumentWorkflowWithSentry(
-  (env: WorkerEnv) => ({
-    dsn: env.SENTRY_DSN,
-    environment: env.SENTRY_ENVIRONMENT || "workers-production",
-    tracesSampleRate: 1.0,
-  }),
-  CheckFlightAlertsWorkflowBase,
-);
-
-// Export with monitor wrapper for cron monitoring
+/**
+ * Export workflow with Sentry monitor wrapper for cron monitoring.
+ * This provides check-in tracking without interfering with workflow execution.
+ */
 export const CheckFlightAlertsWorkflow = withSentryMonitor(
-  InstrumentedWorkflow,
+  CheckFlightAlertsWorkflowBase,
   {
     slug: "check-flight-alerts-cron",
     schedule: "0 */6 * * *",


### PR DESCRIPTION
Sentry's instrumentWorkflowWithSentry wrapper was interfering with Cloudflare Workers workflow step execution, causing steps to hang and time out despite quick underlying API calls.

Root Cause:
- Sentry's workflow instrumentation creates additional overhead that doesn't properly serialize/deserialize across workflow hibernation cycles
- Cloudflare Workflows hibernate and resume, re-executing the run() method
- This can cause spans to duplicate or timeout when workflow context is lost and restored

Solution:
- Removed instrumentWorkflowWithSentry from all three workflows:
  * ProcessSeatsAeroSearchWorkflow
  * ProcessFlightAlertsWorkflow
  * CheckFlightAlertsWorkflow
- Preserved all Sentry monitoring capabilities:
  * captureException() for error tracking (within steps)
  * addBreadcrumb() for execution trails
  * setUser() and setTag() for context
  * workerLogger for structured logging
  * withSentry wrapper at handler level (index.ts)
  * withSentryMonitor for cron check-in tracking (CheckFlightAlertsWorkflow)

Benefits:
✅ Workflows execute without instrumentation overhead ✅ All errors still captured via captureException calls within steps ✅ Breadcrumbs provide execution trail
✅ Cron monitoring still works via withSentryMonitor ✅ HTTP handler monitoring via withSentry in index.ts ✅ No interference with workflow hibernation/resumption

All tests pass (43/43 worker tests)