### PR TITLE
Fix Sentry workflow instrumentation to avoid Cloudflare timeouts

### DIFF
--- a/src/workers/utils/sentry.ts
+++ b/src/workers/utils/sentry.ts
@@ -3,8 +3,40 @@
  * Uses @sentry/cloudflare with withSentry wrapper in index.ts
  */
 
+import type { ExecutionContext } from "@cloudflare/workers-types";
+import { trace } from "@opentelemetry/api";
+import type { CloudflareOptions } from "@sentry/cloudflare";
 import * as Sentry from "@sentry/cloudflare";
+import {
+  CloudflareClient,
+  getDefaultIntegrations,
+  setAsyncLocalStorageAsyncContextStrategy,
+} from "@sentry/cloudflare";
+import {
+  basename,
+  createStackParser,
+  createTransport,
+  getIntegrationsToSetup,
+  initAndBind,
+  nodeStackLineParser,
+  SENTRY_BUFFER_FULL_ERROR,
+  stackParserFromStackParserOptions,
+  startInactiveSpan,
+  startSpanManual,
+  suppressTracing,
+} from "@sentry/core";
 import type { WorkerEnv } from "../env";
+
+type WorkflowTransportResponse = {
+  statusCode?: number;
+  headers?: {
+    [key: string]: string | null;
+    "x-sentry-rate-limits": string | null;
+    "retry-after": string | null;
+  };
+};
+
+type StartSpanOptions = Parameters<typeof startSpanManual>[0];
 
 export function getSentryOptions(env: WorkerEnv) {
   return {
@@ -52,3 +84,362 @@ export function setTag(key: string, value: string | number) {
 
 // Re-export for convenience
 export { Sentry };
+
+let workflowSentryInitialized = false;
+let workflowSentryConfigKey: string | undefined;
+
+function getWorkflowConfigKey(env: WorkerEnv) {
+  return `${env.SENTRY_DSN ?? ""}|${env.SENTRY_ENVIRONMENT ?? ""}`;
+}
+
+const DEFAULT_TRANSPORT_BUFFER_SIZE = 30;
+
+class IsolatedPromiseBuffer {
+  public readonly $: Array<PromiseLike<WorkflowTransportResponse>> = [];
+  private readonly size: number;
+  private readonly taskProducers: Array<
+    () => PromiseLike<WorkflowTransportResponse>
+  > = [];
+
+  constructor(bufferSize = DEFAULT_TRANSPORT_BUFFER_SIZE) {
+    this.size = bufferSize;
+  }
+
+  add(taskProducer: () => PromiseLike<WorkflowTransportResponse>) {
+    if (this.taskProducers.length >= this.size) {
+      return Promise.reject(SENTRY_BUFFER_FULL_ERROR);
+    }
+
+    this.taskProducers.push(taskProducer);
+    return Promise.resolve({} as WorkflowTransportResponse);
+  }
+
+  drain(timeout?: number) {
+    const pendingTasks = [...this.taskProducers];
+    this.taskProducers.length = 0;
+
+    return new Promise<boolean>((resolve) => {
+      const timer = timeout
+        ? setTimeout(() => {
+            resolve(false);
+          }, timeout)
+        : undefined;
+
+      void Promise.all(
+        pendingTasks.map((producer) =>
+          Promise.resolve(producer()).catch(() => {
+            // Ignore transport errors during drain; they'll be handled by Sentry's retry logic
+          }),
+        ),
+      ).then(() => {
+        if (timer) {
+          clearTimeout(timer);
+        }
+        resolve(true);
+      });
+    });
+  }
+}
+
+function makeCloudflareTransport(options: unknown) {
+  const transportOptions = options as {
+    url: string;
+    headers?: HeadersInit;
+    fetchOptions?: RequestInit;
+    bufferSize?: number;
+    recordDroppedEvent: (...args: unknown[]) => void;
+    tunnel?: string;
+  };
+
+  function makeRequest(request: {
+    body: string | Uint8Array<ArrayBufferLike>;
+  }): Promise<WorkflowTransportResponse> {
+    const transportHeaders =
+      "headers" in transportOptions ? transportOptions.headers : undefined;
+    const transportFetchOptions =
+      "fetchOptions" in transportOptions
+        ? transportOptions.fetchOptions
+        : undefined;
+    const body = request.body as BodyInit;
+    const requestOptions: RequestInit = {
+      body,
+      method: "POST",
+      ...(transportFetchOptions ?? {}),
+    };
+
+    if (transportHeaders) {
+      requestOptions.headers = transportHeaders;
+    }
+
+    return suppressTracing(() =>
+      fetch(transportOptions.url, requestOptions).then(
+        (response) =>
+          ({
+            statusCode: response.status,
+            headers: {
+              "x-sentry-rate-limits": response.headers.get(
+                "X-Sentry-Rate-Limits",
+              ),
+              "retry-after": response.headers.get("Retry-After"),
+            },
+          }) satisfies WorkflowTransportResponse,
+      ),
+    );
+  }
+
+  return createTransport(
+    transportOptions,
+    makeRequest,
+    new IsolatedPromiseBuffer(transportOptions.bufferSize),
+  );
+}
+
+function makeFlushLock(ctx?: ExecutionContext) {
+  if (!ctx) {
+    return undefined;
+  }
+
+  let resolveAllDone: () => void = () => {};
+  const allDone = new Promise<void>((resolve) => {
+    resolveAllDone = resolve;
+  });
+  let pending = 0;
+  const originalWaitUntil = ctx.waitUntil.bind(ctx);
+  ctx.waitUntil = (promise) => {
+    pending += 1;
+    return originalWaitUntil(
+      promise.finally(() => {
+        pending -= 1;
+        if (pending === 0) {
+          resolveAllDone();
+        }
+      }),
+    );
+  };
+
+  return {
+    ready: allDone,
+    finalize: () => {
+      if (pending === 0) {
+        resolveAllDone();
+      }
+      return allDone;
+    },
+  } as const;
+}
+
+class SentryCloudflareTracerProvider {
+  private readonly tracers = new Map<string, SentryCloudflareTracer>();
+
+  getTracer(name: string, version?: string, options?: { schemaUrl?: string }) {
+    const key = `${name}@${version ?? ""}:${options?.schemaUrl ?? ""}`;
+    const existing = this.tracers.get(key);
+    if (existing) {
+      return existing;
+    }
+    const tracer = new SentryCloudflareTracer();
+    this.tracers.set(key, tracer);
+    return tracer;
+  }
+}
+
+class SentryCloudflareTracer {
+  startSpan(name: string, options?: Parameters<typeof startInactiveSpan>[0]) {
+    return startInactiveSpan({
+      name,
+      ...options,
+      attributes: {
+        ...options?.attributes,
+        "sentry.cloudflare_tracer": true,
+      },
+    });
+  }
+
+  startActiveSpan<T>(
+    name: string,
+    options: Parameters<typeof startSpanManual>[0] | ((span: unknown) => T),
+    context: unknown,
+    callback?: (span: unknown) => T,
+  ) {
+    const baseOptions =
+      typeof options === "object" && options !== null
+        ? (options as StartSpanOptions)
+        : undefined;
+    const spanOptions = {
+      ...(baseOptions ?? {}),
+      name,
+      attributes: {
+        ...(baseOptions?.attributes ?? {}),
+        "sentry.cloudflare_tracer": true,
+      },
+    } satisfies StartSpanOptions;
+    const fn =
+      typeof options === "function"
+        ? options
+        : typeof context === "function"
+          ? context
+          : (callback ?? (() => {}));
+
+    return startSpanManual(spanOptions, fn as (span: unknown) => T);
+  }
+}
+
+function setupOpenTelemetryTracer() {
+  const tracerProvider = new SentryCloudflareTracerProvider();
+  trace.setGlobalTracerProvider(
+    tracerProvider as unknown as Parameters<
+      typeof trace.setGlobalTracerProvider
+    >[0],
+  );
+}
+
+function workersStackLineParser(
+  getModule: (filename?: string) => string | undefined,
+): ReturnType<typeof nodeStackLineParser> {
+  const [priority, parser] = nodeStackLineParser(getModule);
+
+  const wrappedParser = (line: string) => {
+    const frame = parser(line);
+    if (frame) {
+      const filename = frame.filename;
+      frame.abs_path =
+        filename && !filename.startsWith("/") ? `/${filename}` : filename;
+      frame.in_app = filename !== undefined;
+    }
+    return frame;
+  };
+
+  return [priority, wrappedParser];
+}
+
+function getModuleName(filename?: string) {
+  if (!filename) {
+    return undefined;
+  }
+  return basename(filename, ".js");
+}
+
+const cloudflareStackParser = createStackParser(
+  workersStackLineParser(getModuleName),
+);
+
+function initWorkflowClient(options: CloudflareOptions) {
+  const normalizedOptions: CloudflareOptions = {
+    ...options,
+  };
+
+  if (normalizedOptions.defaultIntegrations === undefined) {
+    normalizedOptions.defaultIntegrations =
+      getDefaultIntegrations(normalizedOptions);
+  }
+
+  const flushLock = makeFlushLock(
+    (normalizedOptions as { ctx?: ExecutionContext }).ctx,
+  );
+  delete (normalizedOptions as { ctx?: ExecutionContext }).ctx;
+
+  const clientOptions = {
+    ...normalizedOptions,
+    stackParser: stackParserFromStackParserOptions(
+      normalizedOptions.stackParser || cloudflareStackParser,
+    ),
+    integrations: getIntegrationsToSetup(normalizedOptions),
+    transport: normalizedOptions.transport || makeCloudflareTransport,
+    flushLock,
+  };
+
+  if (!normalizedOptions.skipOpenTelemetrySetup) {
+    setupOpenTelemetryTracer();
+  }
+
+  return initAndBind(CloudflareClient, clientOptions);
+}
+
+export function ensureWorkflowSentryInitialized(env: WorkerEnv) {
+  const configKey = getWorkflowConfigKey(env);
+
+  if (workflowSentryInitialized && workflowSentryConfigKey === configKey) {
+    return;
+  }
+
+  const options = getSentryOptions(env);
+
+  // Initialize Sentry only when a DSN is provided
+  if (options.dsn) {
+    setAsyncLocalStorageAsyncContextStrategy();
+
+    if (!Sentry.isInitialized()) {
+      initWorkflowClient({
+        ...options,
+        enableDedupe: false,
+      });
+    }
+  }
+
+  workflowSentryInitialized = true;
+  workflowSentryConfigKey = configKey;
+}
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i;
+
+async function deterministicTraceIdFromInstanceId(instanceId: string) {
+  const buffer = await crypto.subtle.digest(
+    "SHA-1",
+    new TextEncoder().encode(instanceId),
+  );
+  return Array.from(new Uint8Array(buffer))
+    .slice(0, 16)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function createPropagationContext(instanceId: string) {
+  const traceId = UUID_REGEX.test(instanceId)
+    ? instanceId.replace(/-/g, "")
+    : await deterministicTraceIdFromInstanceId(instanceId);
+
+  const sampleRand = parseInt(traceId.slice(-4), 16) / 0xffff;
+
+  return {
+    traceId,
+    sampleRand,
+  };
+}
+
+interface WorkflowSentryOptions {
+  workflow: string;
+  instanceId: string;
+}
+
+export async function runWorkflowWithSentry<T>(
+  env: WorkerEnv,
+  options: WorkflowSentryOptions,
+  callback: () => Promise<T>,
+): Promise<T> {
+  ensureWorkflowSentryInitialized(env);
+
+  return Sentry.withScope(async (scope) => {
+    scope.clear();
+
+    scope.setTag("cloudflare.workflow.name", options.workflow);
+    scope.setTag("cloudflare.workflow.instance_id", options.instanceId);
+    scope.setContext("cloudflare.workflow", {
+      name: options.workflow,
+      instanceId: options.instanceId,
+    });
+
+    const propagationContext = await createPropagationContext(
+      options.instanceId,
+    );
+    scope.setPropagationContext(propagationContext);
+
+    try {
+      return await callback();
+    } finally {
+      void Sentry.flush(2000).catch(() => {
+        // Swallow flush failures to avoid interfering with workflow execution
+      });
+    }
+  });
+}

--- a/src/workers/workflows/check-flight-alerts.ts
+++ b/src/workers/workflows/check-flight-alerts.ts
@@ -13,7 +13,11 @@ import { getUserIdsWithActiveDailyAlerts } from "../adapters/alerts.db";
 import type { WorkerEnv } from "../env";
 import { workerLogger } from "../utils/logger";
 import { withSentryMonitor } from "../utils/monitor-wrapper";
-import { addBreadcrumb, captureException } from "../utils/sentry";
+import {
+  addBreadcrumb,
+  captureException,
+  runWorkflowWithSentry,
+} from "../utils/sentry";
 
 /**
  * CheckFlightAlertsWorkflow
@@ -29,76 +33,87 @@ class CheckFlightAlertsWorkflowClass extends WorkflowEntrypoint<
   WorkerEnv,
   Record<string, never>
 > {
-  async run(_event: WorkflowEvent<Record<string, never>>, step: WorkflowStep) {
-    addBreadcrumb("CheckFlightAlertsWorkflow started");
-
-    const userIds = await step.do(
-      "fetch-user-ids-with-active-alerts",
-      {},
+  async run(event: WorkflowEvent<Record<string, never>>, step: WorkflowStep) {
+    return runWorkflowWithSentry(
+      this.env,
+      {
+        workflow: "check-flight-alerts",
+        instanceId: event.instanceId,
+      },
       async () => {
-        try {
-          workerLogger.info("Fetching user IDs with active daily alerts");
-          const ids = await getUserIdsWithActiveDailyAlerts(this.env);
-          workerLogger.info("Found users with active alerts", {
-            count: ids.length,
-          });
-          addBreadcrumb("Fetched user IDs", { count: ids.length });
-          return ids;
-        } catch (error) {
-          captureException(error, {
-            workflow: "check-flight-alerts",
-            step: "fetch-user-ids",
-          });
-          throw error;
+        addBreadcrumb("CheckFlightAlertsWorkflow started");
+
+        const userIds = await step.do(
+          "fetch-user-ids-with-active-alerts",
+          {},
+          async () => {
+            try {
+              workerLogger.info("Fetching user IDs with active daily alerts");
+              const ids = await getUserIdsWithActiveDailyAlerts(this.env);
+              workerLogger.info("Found users with active alerts", {
+                count: ids.length,
+              });
+              addBreadcrumb("Fetched user IDs", { count: ids.length });
+              return ids;
+            } catch (error) {
+              captureException(error, {
+                workflow: "check-flight-alerts",
+                step: "fetch-user-ids",
+              });
+              throw error;
+            }
+          },
+        );
+
+        if (userIds.length === 0) {
+          workerLogger.info("No users with active alerts found");
+          return { queued: 0 };
         }
+
+        return step.do("queue-users-for-processing", {}, async () => {
+          try {
+            workerLogger.info("Queuing users for alert processing", {
+              count: userIds.length,
+            });
+
+            // Queue messages in batches of 100 (Cloudflare's limit per sendBatch call)
+            const BATCH_SIZE = 100;
+            let totalQueued = 0;
+
+            for (let i = 0; i < userIds.length; i += BATCH_SIZE) {
+              const batch = userIds.slice(i, i + BATCH_SIZE);
+
+              await this.env.ALERTS_QUEUE.sendBatch(
+                batch.map((userId) => ({
+                  body: { userId },
+                })),
+              );
+
+              totalQueued += batch.length;
+
+              workerLogger.info("Queued batch", {
+                batchNumber: Math.floor(i / BATCH_SIZE) + 1,
+                batchSize: batch.length,
+                totalQueued,
+              });
+            }
+
+            workerLogger.info("Successfully queued all users", {
+              totalQueued,
+            });
+            addBreadcrumb("Completed queuing", { totalQueued });
+            return { queued: totalQueued };
+          } catch (error) {
+            captureException(error, {
+              workflow: "check-flight-alerts",
+              step: "queue-users",
+              userCount: userIds.length,
+            });
+            throw error;
+          }
+        });
       },
     );
-
-    if (userIds.length === 0) {
-      workerLogger.info("No users with active alerts found");
-      return { queued: 0 };
-    }
-
-    await step.do("queue-users-for-processing", {}, async () => {
-      try {
-        workerLogger.info("Queuing users for alert processing", {
-          count: userIds.length,
-        });
-
-        // Queue messages in batches of 100 (Cloudflare's limit per sendBatch call)
-        const BATCH_SIZE = 100;
-        let totalQueued = 0;
-
-        for (let i = 0; i < userIds.length; i += BATCH_SIZE) {
-          const batch = userIds.slice(i, i + BATCH_SIZE);
-
-          await this.env.ALERTS_QUEUE.sendBatch(
-            batch.map((userId) => ({
-              body: { userId },
-            })),
-          );
-
-          totalQueued += batch.length;
-
-          workerLogger.info("Queued batch", {
-            batchNumber: Math.floor(i / BATCH_SIZE) + 1,
-            batchSize: batch.length,
-            totalQueued,
-          });
-        }
-
-        workerLogger.info("Successfully queued all users", { totalQueued });
-        addBreadcrumb("Completed queuing", { totalQueued });
-        return { queued: totalQueued };
-      } catch (error) {
-        captureException(error, {
-          workflow: "check-flight-alerts",
-          step: "queue-users",
-          userCount: userIds.length,
-        });
-        throw error;
-      }
-    });
   }
 }
 

--- a/src/workers/workflows/process-flight-alerts.ts
+++ b/src/workers/workflows/process-flight-alerts.ts
@@ -13,7 +13,12 @@ import { processDailyAlertsForUser } from "../adapters/alert-processing";
 import { userHasActiveAlerts } from "../adapters/alerts.db";
 import type { WorkerEnv } from "../env";
 import { workerLogger } from "../utils/logger";
-import { addBreadcrumb, captureException, setUser } from "../utils/sentry";
+import {
+  addBreadcrumb,
+  captureException,
+  runWorkflowWithSentry,
+  setUser,
+} from "../utils/sentry";
 
 interface ProcessAlertsParams {
   userId: string;
@@ -32,94 +37,103 @@ export class ProcessFlightAlertsWorkflow extends WorkflowEntrypoint<
   ProcessAlertsParams
 > {
   async run(event: WorkflowEvent<ProcessAlertsParams>, step: WorkflowStep) {
-    const { userId } = event.payload;
-
-    // Set Sentry user context
-    setUser(userId);
-    addBreadcrumb("ProcessFlightAlertsWorkflow started", {
-      userId,
-      instanceId: event.instanceId,
-    });
-
-    workerLogger.info("Starting ProcessFlightAlertsWorkflow", {
-      userId,
-      instanceId: event.instanceId,
-    });
-
-    // Validate user has active alerts (defense-in-depth)
-    const hasActiveAlerts = await step.do(
-      "validate-user-has-active-alerts",
-      {},
+    return runWorkflowWithSentry(
+      this.env,
+      {
+        workflow: "process-flight-alerts",
+        instanceId: event.instanceId,
+      },
       async () => {
-        const hasAlerts = await userHasActiveAlerts(this.env, userId);
+        const { userId } = event.payload;
 
-        if (!hasAlerts) {
-          workerLogger.warn("User has no active alerts", {
+        // Set Sentry user context
+        setUser(userId);
+        addBreadcrumb("ProcessFlightAlertsWorkflow started", {
+          userId,
+          instanceId: event.instanceId,
+        });
+
+        workerLogger.info("Starting ProcessFlightAlertsWorkflow", {
+          userId,
+          instanceId: event.instanceId,
+        });
+
+        // Validate user has active alerts (defense-in-depth)
+        const hasActiveAlerts = await step.do(
+          "validate-user-has-active-alerts",
+          {},
+          async () => {
+            const hasAlerts = await userHasActiveAlerts(this.env, userId);
+
+            if (!hasAlerts) {
+              workerLogger.warn("User has no active alerts", {
+                userId,
+                instanceId: event.instanceId,
+              });
+
+              addBreadcrumb("Validation failed: no active alerts", { userId });
+            }
+
+            return hasAlerts;
+          },
+        );
+
+        // Skip processing if user has no active alerts
+        if (!hasActiveAlerts) {
+          const result = {
+            success: false,
+            reason: "User has no active daily alerts",
+          } as const;
+
+          workerLogger.info("Skipping workflow - no active alerts", {
             userId,
             instanceId: event.instanceId,
-          });
-
-          addBreadcrumb("Validation failed: no active alerts", { userId });
-        }
-
-        return hasAlerts;
-      },
-    );
-
-    // Skip processing if user has no active alerts
-    if (!hasActiveAlerts) {
-      const result = {
-        success: false,
-        reason: "User has no active daily alerts",
-      };
-
-      workerLogger.info("Skipping workflow - no active alerts", {
-        userId,
-        instanceId: event.instanceId,
-      });
-
-      return result;
-    }
-
-    const result = await step.do(
-      `process-alerts-for-user-${userId}`,
-      {
-        retries: {
-          limit: 5,
-          delay: "1 minute",
-          backoff: "exponential",
-        },
-        timeout: "10 minutes",
-      },
-      async () => {
-        try {
-          const result = await processDailyAlertsForUser(this.env, userId);
-
-          addBreadcrumb("Processing completed", {
-            userId,
-            success: result.success,
-            reason: result.reason,
           });
 
           return result;
-        } catch (error) {
-          captureException(error, {
-            workflow: "process-flight-alerts",
-            userId,
-            instanceId: event.instanceId,
-          });
-          throw error;
         }
+
+        const result = await step.do(
+          `process-alerts-for-user-${userId}`,
+          {
+            retries: {
+              limit: 5,
+              delay: "1 minute",
+              backoff: "exponential",
+            },
+            timeout: "10 minutes",
+          },
+          async () => {
+            try {
+              const result = await processDailyAlertsForUser(this.env, userId);
+
+              addBreadcrumb("Processing completed", {
+                userId,
+                success: result.success,
+                reason: result.reason,
+              });
+
+              return result;
+            } catch (error) {
+              captureException(error, {
+                workflow: "process-flight-alerts",
+                userId,
+                instanceId: event.instanceId,
+              });
+              throw error;
+            }
+          },
+        );
+
+        workerLogger.info("Completed ProcessFlightAlertsWorkflow", {
+          userId,
+          instanceId: event.instanceId,
+          success: result.success,
+          reason: result.reason,
+        });
+
+        return result;
       },
     );
-
-    workerLogger.info("Completed ProcessFlightAlertsWorkflow", {
-      userId,
-      instanceId: event.instanceId,
-      success: result.success,
-      reason: result.reason,
-    });
-
-    return result;
   }
 }


### PR DESCRIPTION
## Summary
- replace Sentry's workflow instrumentation with custom wrapper that avoids Cloudflare step timeouts while keeping monitoring
- add bespoke workflow Sentry client, transport, and tracer initialization tailored to Workers
- update workflow implementations to call runWorkflowWithSentry and integrate deterministic tracing

## Testing
- bun run lint
- bun run test:workers
- bun run build
