### PR TITLE
Fix illegal invocation in fetch data

### DIFF
--- a/src/lib/fli/seats-aero/client.ts
+++ b/src/lib/fli/seats-aero/client.ts
@@ -45,7 +45,9 @@ export class SeatsAeroClient {
   constructor(config: SeatsAeroClientConfig) {
     this.apiKey = config.apiKey;
     this.baseUrl = config.baseUrl ?? "https://seats.aero/partnerapi";
-    this.fetchImpl = config.fetchImpl ?? fetch;
+    // Bind fetch to preserve its context when called as a method
+    // This prevents "Illegal invocation" errors in Cloudflare Workers
+    this.fetchImpl = config.fetchImpl ?? fetch.bind(globalThis);
   }
 
   /**


### PR DESCRIPTION
Bind `fetch` to `globalThis` in `SeatsAeroClient` to resolve "Illegal invocation" errors.

The native `fetch` function, when stored as a class property and subsequently called as a method, loses its `this` context, leading to an "Illegal invocation" error. Binding `fetch` to `globalThis` ensures it retains the correct context, preventing this error in the process seats aero workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d430f1c-085f-4a9f-ad6c-9939129b05cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2d430f1c-085f-4a9f-ad6c-9939129b05cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

