### PR TITLE
Reduce seats.aero batch size from 100 to 25

### DIFF
--- a/src/workers/workflows/process-seats-aero-search-pagination.ts
+++ b/src/workers/workflows/process-seats-aero-search-pagination.ts
@@ -112,8 +112,8 @@ export async function paginateSeatsAeroSearch({
         }
 
         const trips = [...uniqueTrips.values()];
-        for (let start = 0; start < trips.length; start += 100) {
-          const batch = trips.slice(start, start + 100);
+        for (let start = 0; start < trips.length; start += 25) {
+          const batch = trips.slice(start, start + 25);
           await upsertTrips(env, {
             searchRequestId: searchRequest.id,
             trips: batch,


### PR DESCRIPTION
- Reduce batch size in process-seats-aero-search-pagination.ts
- This should help prevent database insertion failures with large batches
- Addresses SQL query parameter limit issues (was hitting 2700 params with 100 records × 27 columns)