### PR TITLE
Enable row-level security on all public tables

### DIFF
--- a/migrations/0006_enable_rls.sql
+++ b/migrations/0006_enable_rls.sql
@@ -1,0 +1,37 @@
+-- Enable Row-Level Security on all tables.
+--
+-- Application reads/writes go through Drizzle over a direct Postgres
+-- connection using a privileged role (which bypasses RLS), and the
+-- Cloudflare workers use the Supabase service role key. Both paths are
+-- unaffected by RLS.
+--
+-- Enabling RLS here closes off direct access via the Supabase
+-- PostgREST/Data APIs for the `anon` and `authenticated` roles. With RLS
+-- enabled and no permissive policies defined, all access through those
+-- roles is denied by default, so tables are not readable or writable by
+-- arbitrary clients holding only the publishable/anon key.
+--
+-- FORCE ROW LEVEL SECURITY additionally ensures the table owner is also
+-- subject to policies, preventing accidental data exposure if the
+-- application ever connects under the owner role through PostgREST.
+
+ALTER TABLE "airport" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "airport" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+ALTER TABLE "airline" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "airline" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+ALTER TABLE "alert" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "alert" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+ALTER TABLE "notification" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "notification" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+ALTER TABLE "alert_notification" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "alert_notification" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+ALTER TABLE "seats_aero_search_request" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "seats_aero_search_request" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+ALTER TABLE "seats_aero_availability_trip" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "seats_aero_availability_trip" FORCE ROW LEVEL SECURITY;

--- a/migrations/meta/0006_snapshot.json
+++ b/migrations/meta/0006_snapshot.json
@@ -1,0 +1,666 @@
+{
+  "id": "a1b2c3d4-0006-4e5f-8a9b-0c1d2e3f4a5b",
+  "prevId": "c79b14a9-3726-491a-83c3-7c197b688c71",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.airline": {
+      "name": "airline",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iata": {
+          "name": "iata",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icao": {
+          "name": "icao",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.airport": {
+      "name": "airport",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iata": {
+          "name": "iata",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icao": {
+          "name": "icao",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(point)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert": {
+      "name": "alert",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_end": {
+          "name": "alert_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_notification": {
+      "name": "alert_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flight_data_snapshot": {
+          "name": "flight_data_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_notification_notification_id_notification_id_fk": {
+          "name": "alert_notification_notification_id_notification_id_fk",
+          "tableFrom": "alert_notification",
+          "tableTo": "notification",
+          "columnsFrom": ["notification_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_notification_alert_id_alert_id_fk": {
+          "name": "alert_notification_alert_id_alert_id_fk",
+          "tableFrom": "alert_notification",
+          "tableTo": "alert",
+          "columnsFrom": ["alert_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seats_aero_availability_trip": {
+      "name": "seats_aero_availability_trip",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "search_request_id": {
+          "name": "search_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_trip_id": {
+          "name": "api_trip_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_route_id": {
+          "name": "api_route_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_availability_id": {
+          "name": "api_availability_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_airport": {
+          "name": "origin_airport",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_airport": {
+          "name": "destination_airport",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "travel_date": {
+          "name": "travel_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flight_numbers": {
+          "name": "flight_numbers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "carriers": {
+          "name": "carriers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aircraft_types": {
+          "name": "aircraft_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departure_time": {
+          "name": "departure_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrival_time": {
+          "name": "arrival_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stops": {
+          "name": "stops",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_distance_miles": {
+          "name": "total_distance_miles",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cabin_class": {
+          "name": "cabin_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mileage_cost": {
+          "name": "mileage_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remaining_seats": {
+          "name": "remaining_seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_taxes": {
+          "name": "total_taxes",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxes_currency": {
+          "name": "taxes_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taxes_currency_symbol": {
+          "name": "taxes_currency_symbol",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_created_at": {
+          "name": "api_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_updated_at": {
+          "name": "api_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_trips_route_date_created": {
+          "name": "idx_trips_route_date_created",
+          "columns": [
+            {
+              "expression": "origin_airport",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_airport",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "travel_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trips_created": {
+          "name": "idx_trips_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trips_search_request": {
+          "name": "idx_trips_search_request",
+          "columns": [
+            {
+              "expression": "search_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "seats_aero_availability_trip_search_request_id_seats_aero_search_request_id_fk": {
+          "name": "seats_aero_availability_trip_search_request_id_seats_aero_search_request_id_fk",
+          "tableFrom": "seats_aero_availability_trip",
+          "tableTo": "seats_aero_search_request",
+          "columnsFrom": ["search_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "seats_aero_availability_trip_api_trip_id_unique": {
+          "name": "seats_aero_availability_trip_api_trip_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["api_trip_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seats_aero_search_request": {
+      "name": "seats_aero_search_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "origin_airport": {
+          "name": "origin_airport",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_airport": {
+          "name": "destination_airport",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_start_date": {
+          "name": "search_start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_end_date": {
+          "name": "search_end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_more": {
+          "name": "has_more",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "processed_count": {
+          "name": "processed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_search_requests_status": {
+          "name": "idx_search_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "seats_aero_search_request_origin_airport_destination_airport_search_start_date_search_end_date_unique": {
+          "name": "seats_aero_search_request_origin_airport_destination_airport_search_start_date_search_end_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "origin_airport",
+            "destination_airport",
+            "search_start_date",
+            "search_end_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1760682054592,
       "tag": "0005_sour_madame_hydra",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1776556800000,
+      "tag": "0006_enable_rls",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Enable (and FORCE) RLS on airport, airline, alert, notification,
alert_notification, seats_aero_search_request, and
seats_aero_availability_trip so that access through the Supabase
PostgREST/Data APIs with the anon or authenticated role is denied by
default. The application continues to work unchanged because Drizzle
uses a direct Postgres connection with a privileged role and the
workers use the Supabase service role key, both of which bypass RLS.